### PR TITLE
(hybris) rename the android dbus group to adbus.

### DIFF
--- a/include/private/android_filesystem_config.h
+++ b/include/private/android_filesystem_config.h
@@ -202,7 +202,7 @@ static const struct android_id_info android_ids[] = {
     { "sdcard_all",    AID_SDCARD_ALL, },
     { "logd",          AID_LOGD, },
     { "shared_relro",  AID_SHARED_RELRO, },
-    { "dbus",          AID_DBUS, },
+    { "adbus",         AID_DBUS, },
     { "tlsdate",       AID_TLSDATE, },
     { "mediaex",       AID_MEDIA_EX, },
     { "audioserver",   AID_AUDIOSERVER, },


### PR DESCRIPTION
The android dbus group with id 1038 conflicts with the dbus group
of sailfish with id 81. Currently we don't need dbus inside droid-hal
therefore it should be safe to rename this group (for now).

JB#39668